### PR TITLE
Fix hover flicker on work experience cards

### DIFF
--- a/src/components/WorkExperience.jsx
+++ b/src/components/WorkExperience.jsx
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import firebase from "./firebase.js";
 import "../styles/Main.css";
 
-import {CardColumns, Card, Button} from "react-bootstrap";
+import {Card, Button} from "react-bootstrap";
 
 class WorkExperience extends Component {
     constructor(props) {
@@ -69,11 +69,11 @@ class WorkExperience extends Component {
         return (
             <div className="page">
                 <h1 className="pageTitle">Work Experience</h1>
-                <CardColumns>
+                <div className="projGrid">
                     {this.state.cards.map((card) => (
                         card
                     ))}
-                </CardColumns>
+                </div>
             </div>
         );
     }


### PR DESCRIPTION
## Summary

- Replaced Bootstrap's `CardColumns` with `<div className="projGrid">` in `WorkExperience.jsx`
- Removed the now-unused `CardColumns` import

## Why

`CardColumns` uses CSS multi-column layout (`column-count: 3`). When a card's hover state triggers `transform: translateY(-2px)`, the multi-column engine recalculates column flow for the entire container, causing cards in columns 2 and 3 to flicker in and out. Cards in column 1 were unaffected.

`projGrid` uses `display: grid`, which handles transforms per-element via the compositor without triggering layout reflow — matching the same pattern already used by `Projects.jsx` with no flicker.

## Test plan

- [ ] Navigate to Work Experience page
- [ ] Hover over each card — no flickering on any card
- [ ] Verify cards display in the same 3-column grid layout as before

🤖 Generated with [Claude Code](https://claude.ai/claude-code)