### PR TITLE
Standardize cards: use Home-style layout on Projects and Work Experience

### DIFF
--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -29,19 +29,17 @@ class Projects extends Component {
             }
 
             self.state.cards.push(
-                <Card key={doc.data().name} bg="light" border="dark" className="text-center card">
-                    <Card.Header className='cardHeader'>
-                        <Card.Title>{doc.data().name}</Card.Title>
-                    </Card.Header>
+                <Card key={doc.data().name} className="card">
                     <Card.Img variant="top" src={doc.data().url} />
                     <Card.Body>
+                      <Card.Title className="cardTitle">{doc.data().name}</Card.Title>
                       <Card.Text className='cardText'>{doc.data().description}</Card.Text>
+                      <div className="cardLinks">
+                        {newKeys.map((key, index) => (
+                            <Button key={index} className='cardLink' variant="link" href={doc.data()[key]} target="_blank" onClick={() => self.logClick(key, doc.data().name)}>{key}</Button>
+                        ))}
+                      </div>
                     </Card.Body>
-                    <Card.Footer className="text-muted">
-                      {newKeys.map((key, index) => (
-                          <Button key={index} className='cardButton' variant="primary" href={doc.data()[key]} target="_blank" onClick={() => self.logClick(key, doc.data().name)}>{key}</Button>
-                      ))}
-                    </Card.Footer>
                   </Card>
             );
 

--- a/src/components/WorkExperience.jsx
+++ b/src/components/WorkExperience.jsx
@@ -39,20 +39,18 @@ class WorkExperience extends Component {
                 }
 
                 self.state.cards.push(
-                    <Card key={doc.data().name} bg="light" border="dark" className="text-center card">
-                        <Card.Header className='cardHeader'>
-                            <Card.Title>{doc.data().role} @ {doc.data().name}</Card.Title>
-                            <Card.Subtitle>{doc.data().startDate} - {doc.data().endDate}</Card.Subtitle>
-                        </Card.Header>
+                    <Card key={doc.data().name} className="card">
                         <Card.Img variant="top" src={doc.data().url} />
                         <Card.Body>
+                            <Card.Title className="cardTitle">{doc.data().role} @ {doc.data().name}</Card.Title>
+                            <p style={{fontSize: 13, color: '#6c757d', margin: '0 0 8px', fontFamily: 'Livvic, sans-serif'}}>{doc.data().startDate} - {doc.data().endDate}</p>
                             <Card.Text className='cardText'>{doc.data().description}</Card.Text>
+                            <div className="cardLinks">
+                                {newKeys.map((key, index) => (
+                                    <Button key={index} className='cardLink' variant="link" href={doc.data()[key]} target="_blank" onClick={() => self.logClick(key, doc.data().name)}>{key}</Button>
+                                ))}
+                            </div>
                         </Card.Body>
-                        <Card.Footer className="text-muted">
-                            {newKeys.map((key, index) => (
-                                <Button key={index} className='cardButton' variant="primary" href={doc.data()[key]} target="_blank" onClick={() => self.logClick(key, doc.data().name)}>{key}</Button>
-                            ))}
-                        </Card.Footer>
                     </Card>
                 );
             });


### PR DESCRIPTION
## Summary

- Replaced `Card.Header` / `Card.Footer` pattern with a single `Card.Body` in both `Projects.jsx` and `WorkExperience.jsx`
- Image now sits at the top of the card (before the body), matching the Home page layout
- Buttons changed from full `variant="primary"` to pill-style `cardLink` links wrapped in `<div className="cardLinks">`
- Work Experience cards keep the role/company title and add a muted date line below the title

## Why

The cards on the Work Experience and Projects pages used an older Bootstrap Card.Header + Card.Footer structure that conflicted visually with the redesigned soft-card style already applied to the Home page's recent projects section.

## Test plan

- [ ] Navigate to /projects — cards show image, title, description, pill links; no header/footer chrome
- [ ] Navigate to /work-experience — cards show image, role @ company, muted date range, description, pill links
- [ ] Compare both pages against Home's "Recent Projects" section — all three should look identical in structure

🤖 Generated with [Claude Code](https://claude.ai/claude-code)