### PR TITLE
fix: full-width layout for project grid, contact form, and footer

### DIFF
--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -99,7 +99,7 @@ class Navigation extends Component {
         <Route path="/resume" component={Resume}/>
 
         <div>
-          <footer>Copyright &copy; 2020-{currentYear} Tanay Sonthalia</footer>
+          <footer className="footer">Copyright &copy; 2020-{currentYear} Tanay Sonthalia</footer>
         </div>
       </HashRouter>
     );

--- a/src/styles/Main.css
+++ b/src/styles/Main.css
@@ -164,7 +164,7 @@ body {
 /* ---------- UNIFIED GRID (replaces CardColumns) ---------- */
 .projGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: 24px;
 }
 
@@ -263,7 +263,6 @@ body {
 }
 
 .contact form {
-  max-width: 720px;
 }
 
 /* ---------- RESUME ---------- */


### PR DESCRIPTION
## Summary
- `auto-fill` → `auto-fit` on `.projGrid` so 3 project cards stretch to fill the row instead of leaving an empty 4th column slot
- Removed `max-width: 720px` from `.contact form` so the contact form spans the full content area on wide screens
- Added `className="footer"` to `<footer>` in `Navigation.jsx` so the `.footer` CSS (centering, font, padding, border-top) actually applies

## Test plan
- [ ] Home page: Recent Projects section cards fill the full row width
- [ ] Home page: Contact form spans full content width
- [ ] All pages: Footer is centered with proper Teko font and top border

🤖 Generated with [Claude Code](https://claude.com/claude-code)