### PR TITLE
standardize cards: migrate CommunityService and Tutorials to CSS grid layout

### DIFF
--- a/src/components/CommunityService.jsx
+++ b/src/components/CommunityService.jsx
@@ -2,15 +2,13 @@ import React, { Component } from "react";
 import firebase from "./firebase.js";
 import "../styles/Main.css";
 
-import {CardColumns, Card, Button} from "react-bootstrap";
+import {Card, Button} from "react-bootstrap";
 
 class CommunityService extends Component {
   constructor(props) {
     super(props);
 
     this.state = {
-      data: [],
-      urls: [],
       cards: [],
     }
 
@@ -19,10 +17,6 @@ class CommunityService extends Component {
 
     db.collection("communityService").orderBy("date", "desc").get().then(function(querySnapshot) {
         querySnapshot.forEach(function(doc) {
-            // doc.data() is never undefined for query doc snapshots
-            // console.log(doc.data().name);
-            //
-            // console.log(Object.keys(doc.data()));
             var keys = Object.keys(doc.data())
             var newKeys = []
             for (var index in keys) {
@@ -32,19 +26,17 @@ class CommunityService extends Component {
             }
 
             self.state.cards.push(
-                <Card key={doc.data().name} bg="light" border="dark" className="text-center card">
-                    <Card.Header className='cardHeader'>
-                        <Card.Title>{doc.data().name}</Card.Title>
-                    </Card.Header>
+                <Card key={doc.data().name} className="card">
                     <Card.Img variant="top" src={doc.data().url} />
                     <Card.Body>
+                        <Card.Title className="cardTitle">{doc.data().name}</Card.Title>
                         <Card.Text className='cardText'>{doc.data().description}</Card.Text>
+                        <div className="cardLinks">
+                            {newKeys.map((key, index) => (
+                                <Button key={index} className='cardLink' variant="link" href={doc.data()[key]} target="_blank" onClick={() => self.logClick(key, doc.data().name)}>{key}</Button>
+                            ))}
+                        </div>
                     </Card.Body>
-                    <Card.Footer className="text-muted">
-                        {newKeys.map((key, index) => (
-                            <Button key={index} variant="primary" className='cardButton' href={doc.data()[key]} target="_blank" onClick={() => self.logClick(key, doc.data().name)}>{key}</Button>
-                        ))}
-                    </Card.Footer>
                 </Card>
             );
         });
@@ -61,11 +53,9 @@ class CommunityService extends Component {
     return (
       <div className="page">
         <h1 className="pageTitle">Community Service</h1>
-        <CardColumns>
-          {this.state.cards.map((card) => (
-              card
-          ))}
-        </CardColumns>
+        <div className="projGrid">
+          {this.state.cards}
+        </div>
       </div>
     );
   }

--- a/src/components/Tutorials.jsx
+++ b/src/components/Tutorials.jsx
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import firebase from "./firebase.js";
 import "../styles/Main.css";
 
-import {CardColumns, Card, Button} from "react-bootstrap";
+import {Card, Button} from "react-bootstrap";
 
 class Tutorials extends Component {
 
@@ -10,8 +10,6 @@ class Tutorials extends Component {
     super(props);
 
     this.state = {
-      data: [],
-      urls: [],
       cards: [],
     }
 
@@ -20,10 +18,6 @@ class Tutorials extends Component {
 
     db.collection("tutorials").orderBy("date", "desc").get().then(function(querySnapshot) {
         querySnapshot.forEach(function(doc) {
-            // doc.data() is never undefined for query doc snapshots
-            // console.log(doc.data().name);
-            //
-            // console.log(Object.keys(doc.data()));
             var keys = Object.keys(doc.data())
             var newKeys = []
             for (var index in keys) {
@@ -33,19 +27,17 @@ class Tutorials extends Component {
             }
 
             self.state.cards.push(
-                <Card key={doc.data().name} bg="light" border="dark" className="text-center card">
-                    <Card.Header className='cardHeader'>
-                        <Card.Title>{doc.data().name}</Card.Title>
-                    </Card.Header>
+                <Card key={doc.data().name} className="card">
                     <Card.Body>
+                        <Card.Title className="cardTitle">{doc.data().name}</Card.Title>
                         <Card.Text className='cardText'>{doc.data().description}</Card.Text>
+                        <div className="cardLinks">
+                            {newKeys.map((key, index) => (
+                                <Button key={index} className='cardLink' variant="link" href={doc.data()[key]} target="_blank" onClick={() => self.logClick(key, doc.data().name)}>{key}</Button>
+                            ))}
+                        </div>
                     </Card.Body>
-                    <Card.Footer className="text-muted">
-                        {newKeys.map((key, index) => (
-                            <Button key={index} className='cardButton' variant="primary" href={doc.data()[key]} target="_blank" onClick={() => self.logClick(key, doc.data().name)}>{key}</Button>
-                        ))}
-                    </Card.Footer>
-                  </Card>
+                </Card>
             );
         });
         self.setState({cards: self.state.cards});
@@ -61,11 +53,9 @@ class Tutorials extends Component {
     return (
       <div className="page">
         <h1 className="pageTitle">Tutorials</h1>
-        <CardColumns>
-          {this.state.cards.map((card) => (
-              card
-          ))}
-        </CardColumns>
+        <div className="projGrid">
+          {this.state.cards}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Summary

- Replaced `CardColumns` with `<div className="projGrid">` (CSS grid) in both Community Service and Tutorials
- Moved card title into `Card.Body` (removing `Card.Header`) and removed `Card.Footer`
- Changed action buttons from `variant="primary"` to `variant="link"` with `className="cardLink"` (pill style)
- Cleaned up unused `data`/`urls` state fields and dead comments

## What this fixes

Community Service and Tutorials were still using the old Bootstrap `CardColumns` layout with styled header/footer sections, while Projects and Work Experience had already been migrated to the unified grid + modern card style. This PR brings all four tabs to the same visual standard.

## Reviewer notes

No logic changes — purely structural/visual. The `projGrid` CSS class and card styles in `Main.css` already support this layout; no CSS changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)